### PR TITLE
Schedule to build and publish every midnight.

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,6 +1,8 @@
 # Copyright 2019 Thomas Brown (tabsoftwareconsulting@gmail.com)
 
-on: push
+on:
+  schedule:
+  - cron: "0 0 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
This is an experiment to run for a while.  There is a lot more to do for this to be generally useful and not too greedy with resources.

1. Build only when there are changes to the Emacs repository.
  * keep a `revision.txt` in the last release?
  * look at the date of the last release?
  * use the commit graph and the last commit id?
2. Keep the pace of nightlies at something reasonable (weeklies?)
3. Build all the tags that are not yet released.
  * reconcile the releases with the tags in the Emacs repository?
  * needs a limit
4. Name the tag builds more nicely.
  * `26.3` would be the expected format.
  * maybe `tee3-emacs-build-ci-26.3` since it provides some indication of the source?
5. Figure out a better tag format.  Having just the version would be nice and would enable (3)
  * tee3-emacs-build-ci-26.3 for taged versions (releases and prereleases)
    * maybe this should include the build date?
  * tee3-emacs-build-ci-GGGGGGG for nightlies/weeklies/etc
    * maybe this should include the build date?
